### PR TITLE
Remove dead code to set children type and commented styles.

### DIFF
--- a/src/Fixed.js
+++ b/src/Fixed.js
@@ -3,36 +3,15 @@ import React from 'react';
 
 let Fixed = React.createClass({
 
-    propTypes: {
-        type: React.PropTypes.string.isRequired
-    },
-
-    getDefaultProps() {
-        return {
-            type: 'columns'
-        }
-    },
-
     render() {
         let classes = ['Fixed'];
         if (this.props.className) {
             classes.push(this.props.className);
         }
 
-        let styles;
-        if (this.props.type === 'rows') {
-            styles = {
-                position: 'relative'
-                //width: '100%'
-            };
-        } else {
-            styles = {
-                position: 'relative'
-                //height: '100%'
-            };
-        }
-
-        return <div className={classes.join(' ')} style={styles}>{this.props.children}</div>;
+        return <div className={classes.join(' ')} style={{
+            position: 'relative'
+        }}>{this.props.children}</div>;
     }
 });
 

--- a/src/Flex.js
+++ b/src/Flex.js
@@ -4,42 +4,20 @@ import VendorPrefix from 'react-vendor-prefix';
 
 let Flex = React.createClass({
 
-    propTypes: {
-        type: React.PropTypes.string.isRequired
-    },
-
-    getDefaultProps() {
-        return {
-            type: 'columns'
-        }
-    },
-
     render() {
         let classes = ['Flex'];
         if (this.props.className) {
             classes.push(this.props.className);
         }
 
-        let style;
-        if (this.props.type === 'rows') {
-            style = {
-                flex: 1,
-                position: 'relative'
-            };
-        } else {
-            style = {
-                flex: 1,
-                position: 'relative'
-                //height: '100%',
-                //minHeight: '100%'
-            };
-        }
-        let prefixed = VendorPrefix.prefix({styles: style});
+        let prefixed = VendorPrefix.prefix({styles: {
+            flex: 1,
+            position: 'relative'
+        }});
 
         return <div className={classes.join(' ')} style={prefixed.styles}>{this.props.children}</div>;
     }
 });
-
 
 
 export default Flex;

--- a/src/Layout.js
+++ b/src/Layout.js
@@ -1,6 +1,7 @@
 import React from 'react/addons';
 import VendorPrefix from 'react-vendor-prefix';
 
+var {Children} = React;
 
 let Layout = React.createClass({
 
@@ -29,11 +30,6 @@ let Layout = React.createClass({
                 flex: 1,
                 flexDirection: 'column',
 
-                //position: 'relative',
-                //height: '100%',
-                //minHeight: '100%'
-
-                //width: '100%',
                 position: 'absolute',
                 left: 0,
                 right: 0,
@@ -47,7 +43,6 @@ let Layout = React.createClass({
                 flex: 1,
                 flexDirection: 'row',
 
-                //height: '100%',
                 position: 'absolute',
                 left: 0,
                 right: 0,
@@ -60,19 +55,7 @@ let Layout = React.createClass({
 
         let prefixed = VendorPrefix.prefix({styles: style});
 
-        let type = this.props.type;
-        let index = 0;
-        let elements = [];
-        if (this.props.children) {
-             elements = this.props.children.map((child) => {
-                return React.addons.cloneWithProps(child, {
-                    type: type,
-                    key: index++
-                });
-            });
-        }
-
-        return <div className={classes.join(' ')} style={prefixed.styles}>{elements}</div>;
+        return <div className={classes.join(' ')} style={prefixed.styles}>{this.props.children}</div>;
     }
 });
 

--- a/test/Layout-test.js
+++ b/test/Layout-test.js
@@ -36,10 +36,8 @@ describe('Layout', function () {
         expect(fixed.type.displayName).to.equal('Fixed');
         expect(flex.type.displayName).to.equal('Flex');
 
-        expect(fixed.props.type).to.equal('rows');
         expect(fixed.props.className).to.equal('header');
 
-        expect(flex.props.type).to.equal('rows');
         expect(flex.props.className).to.equal('content');
     });
 });


### PR DESCRIPTION
The code that mapped over children wasn't using the `React.Children` api (https://facebook.github.io/react/docs/top-level-api.html#react.children) and so would also sometimes error. The children don't do anythign important with the type prop, so kill that.
